### PR TITLE
Add support for generic arguments types

### DIFF
--- a/NBrowse.Test/src/Reflection/Mono/CecilTypeTest.cs
+++ b/NBrowse.Test/src/Reflection/Mono/CecilTypeTest.cs
@@ -27,6 +27,17 @@ namespace NBrowse.Test.Reflection.Mono
 		}
 
 		[Test]
+		[TestCase("MemberTypeParameters0", "")]
+		[TestCase("MemberTypeParameters1", "CecilTypeTest+CecilMemberTypeParameters`2+TParameter1")]
+		[TestCase("MemberTypeParameters2", "CecilTypeTest+CecilMemberTypeParameters`2+TParameter1,CecilTypeTest+CecilMemberTypeParameters`2+TParameter2")]
+		public void Arguments(string fieldName, string expected)
+		{
+			var fieldType = CecilTypeTest.GetType("CecilMemberTypeParameters").Fields.First(field => field.Name == fieldName).Type;
+			Assert.That(string.Join(",", fieldType.Arguments.Select(p => p.Name)),
+				Is.EqualTo(expected));
+		}
+
+		[Test]
 		[TestCase(nameof(CecilTypeBaseOrNullIsDefined), "Stream")]
 		public void BaseOrNullIsDefined(string name, string expected)
 		{
@@ -317,7 +328,7 @@ namespace NBrowse.Test.Reflection.Mono
 			}
 		}
 
-		private static class CecilTypeParameters0
+		private class CecilTypeParameters0
 		{
 		}
 
@@ -327,6 +338,13 @@ namespace NBrowse.Test.Reflection.Mono
 
 		private class CecilTypeParameters2<TParameter1, TParameter2>
 		{
+		}
+
+		private class CecilMemberTypeParameters<TParameter1, TParameter2>
+		{
+			public CecilTypeParameters0 MemberTypeParameters0;
+			public CecilTypeParameters1<TParameter1> MemberTypeParameters1;
+			public CecilTypeParameters2<TParameter1, TParameter2> MemberTypeParameters2;
 		}
 
 		private static class CecilTypeParent

--- a/NBrowse/src/Reflection/Mono/CecilType.cs
+++ b/NBrowse/src/Reflection/Mono/CecilType.cs
@@ -12,6 +12,17 @@ namespace NBrowse.Reflection.Mono
 			this.definition?.CustomAttributes.Select(attribute => new CecilAttribute(attribute, this.project)) ??
 			Array.Empty<CecilAttribute>();
 
+		public override IEnumerable<Type> Arguments
+		{
+			get
+			{
+				if (!this.reference.IsGenericInstance)
+					return Array.Empty<Type>();
+				return ((GenericInstanceType) this.reference).GenericArguments.Select(arg =>
+					new CecilType(arg, this.project));
+			}
+		}
+
 		public override Type BaseOrNull => this.definition?.BaseType != null
 			? new CecilType(this.definition.BaseType, this.project)
 			: default(Type);

--- a/NBrowse/src/Reflection/Type.cs
+++ b/NBrowse/src/Reflection/Type.cs
@@ -18,6 +18,10 @@ namespace NBrowse.Reflection
 			return !lhs?.Equals(rhs) ?? !ReferenceEquals(rhs, null);
 		}
 
+		[Description("Generic arguments types")]
+		[JsonIgnore]
+		public abstract IEnumerable<Type> Arguments { get; }
+
 		[Description("Custom attributes (resolved type only)")]
 		[JsonIgnore]
 		public abstract IEnumerable<Attribute> Attributes { get; }


### PR DESCRIPTION
GenericInstanceType [0] has a field arguments, which corresponds to the
generic arguments of a type. This commit adds support to this
information, making it possible to, for instance, get `int` for a type
definition of `IList<int>`.

[0] https://github.com/jbevain/cecil/blob/0.11/Mono.Cecil/GenericInstanceType.cs